### PR TITLE
Override PerformFetch in Jobs/Sample.iOS so that it will work in fetch mode.

### DIFF
--- a/Jobs/Sample.iOS/AppDelegate.cs
+++ b/Jobs/Sample.iOS/AppDelegate.cs
@@ -18,4 +18,7 @@ namespace Sample.iOS
 			return base.FinishedLaunching(app, options);
 		}
 	}
+
+	public override void PerformFetch(UIApplication application, Action<UIBackgroundFetchResult> completionHandler)
+		=> this.ShinyPerformFetch(completionHandler);
 }


### PR DESCRIPTION
I watched your Shiny 2.0 presentation at https://www.youtube.com/watch?v=9nCFwSTkeCgwas and was trying to use trying to exercise Simulate iOS Background Fetch like you did in your presentation using the Jobs sample here.  I configure my local build to only use "fetch".  I had to override PerformFetch() for it to work.  Can we add the override to the Jobs sample, or if it doesn't apply when using BgTasksJobManager maybe we could add the lines but have it documented/commented out.  Let me know your thoughts.